### PR TITLE
Add boot_timeout setting

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -100,6 +100,7 @@ class Arbiter(object):
         self.address = self.cfg.address
         self.num_workers = self.cfg.workers
         self.timeout = self.cfg.timeout
+        self.boot_timeout = self.cfg.boot_timeout
         self.proc_name = self.cfg.proc_name
 
         self.log.debug('Current configuration:\n{0}'.format(
@@ -492,7 +493,18 @@ class Arbiter(object):
         workers = list(self.WORKERS.items())
         for (pid, worker) in workers:
             try:
-                if time.time() - worker.tmp.last_update() <= self.timeout:
+                if worker.booted:
+                    if not self.timeout:
+                        has_not_timed_out = True
+                    else:
+                        has_not_timed_out = time.time() - worker.tmp.last_update() <= self.timeout
+                else:
+                    if self.boot_timeout:
+                        has_not_timed_out = time.time() - worker.tmp.last_update() <= self.boot_timeout
+                    else:
+                        has_not_timed_out = time.time() - worker.tmp.last_update() <= self.timeout
+
+                if has_not_timed_out:
                     continue
             except (OSError, ValueError):
                 continue

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -754,6 +754,23 @@ class Timeout(Setting):
         """
 
 
+
+class BootTimeout(Setting):
+    name = "boot_timeout"
+    section = "Worker Processes"
+    cli = ["--boot-timeout"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = int
+    default = 30
+    desc = """\
+        This implements the same behavior but is applied for workers before
+        they enter the booted state. This is useful if the worker may be slow
+        to boot but should have a lower timeout once started.
+        """
+
+
+
 class GracefulTimeout(Setting):
     name = "graceful_timeout"
     section = "Worker Processes"

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -136,6 +136,10 @@ class Worker(object):
         self.cfg.post_worker_init(self)
 
         # Enter main run loop
+        # Notify before setting booted to True, in case the arbiter evaluates
+        # the timeout after booted is set to True, but before the worker has
+        # called notify
+        self.notify()
         self.booted = True
         self.run()
 


### PR DESCRIPTION
Summary: We have an issue with our gunicorn dynos where the workers
frequently timeout during boot due to our 29s timeout. That is a
reasonable timeout once they start handling requests, but it doesn't
really make sense for booting, which is slower and not bounded by
Heroku's 30 second max response time for requests.

Unfortunately, gunicorn currently only lets us set a single timeout that
controls both the worker booting and responding to requests. This adds
a new setting to guicorn, `--boot-timeout`, which would allow us to set
a longer timeout for workers when they are booting.